### PR TITLE
Add `extra.branch-alias` config at `composer.json` in order to allow installs from dev versions while respecting SemVer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
     },
     "autoload": {
         "psr-4": { "SecIT\\ImapBundle\\": "" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
     }
 }


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |