### PR TITLE
feat: drop support of php < 7.1.3, fix deprecation in symfony 6

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('imap');
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.0",
         "symfony/framework-bundle": "~4.0|~5.0|~6.0",
         "symfony/dependency-injection": "~4.0|~5.0|~6.0",
         "php-imap/php-imap": "~2.0|~3.0|~4.0|~5.0"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1.3",
         "symfony/framework-bundle": "~4.0|~5.0|~6.0",
         "symfony/dependency-injection": "~4.0|~5.0|~6.0",
         "php-imap/php-imap": "~2.0|~3.0|~4.0|~5.0"


### PR DESCRIPTION
https://github.com/secit-pl/imap-bundle/issues/20

The minium PHP-Version is >= 7.1.3, as lower bound.
This is because of [symfony/](https://packagist.org/packages/symfony/)framework-bundle
https://packagist.org/packages/symfony/framework-bundle#v4.0.0

So it is save to upgrade to this version.