### PR TITLE
feat: update minimum php-imap version for ^2.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=7.1.3",
         "symfony/framework-bundle": "~4.0|~5.0|~6.0",
         "symfony/dependency-injection": "~4.0|~5.0|~6.0",
-        "php-imap/php-imap": "~2.0|~3.0|~4.0|~5.0"
+        "php-imap/php-imap": "^2.0.4|~3.0|~4.0|~5.0"
     },
     "autoload": {
         "psr-4": { "SecIT\\ImapBundle\\": "" }


### PR DESCRIPTION
https://github.com/secit-pl/imap-bundle/issues/19

I did give a wrong answer in the linked issue. 

2.0 to 2.0.3 of php-imap is missing the required `ext-imap: *`
https://packagist.org/packages/php-imap/php-imap#2.0.3

I find this out, after i noticed that ext-imap was not installed at my local machine.