### PR TITLE
feat: drop support of php < 7, update readme

### DIFF
--- a/Command/ValidateConnectionsCommand.php
+++ b/Command/ValidateConnectionsCommand.php
@@ -1,0 +1,122 @@
+<?php
+namespace SecIT\ImapBundle\Command;
+
+use SecIT\ImapBundle\Service\Imap;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ *
+ * USE: php bin/console imap-bundle:validate-connections
+ */
+# Symfony > 5.3
+##[AsCommand(name: 'imap-bundle:validate-connections', description: 'Validate if all Mailboxes can connect correct. If not, return 1')]
+class ValidateConnectionsCommand extends Command
+{
+    protected static $defaultName = 'imap-bundle:validate-connections';
+    protected static $defaultDescription = 'Validate if all Mailboxes can connect correct. If not, return 1';
+
+    protected ?InputInterface $input;
+	protected ?OutputInterface $output;
+	protected bool $failed = false;
+
+	public function __construct(protected Imap $imap, protected ParameterBagInterface $parameter)
+    {
+	    parent::__construct();
+
+        $this->output = null;
+	    $this->input = null;
+	}
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setDefinition([
+                new InputArgument('connections', InputArgument::IS_ARRAY, 'Connections. Will fail if not correct'),
+            ]);
+    }
+
+    /**
+     * @return string[]
+     * @throws \Exception
+     */
+	protected function getRow(string $key, array $connection): array
+    {
+        $connection_test = $this->imap->testConnection($key, false);
+        if(!$connection_test)
+        {$this->failed = true;}
+
+	    return [
+           $key,
+           ($connection_test) ? 'SUCCESS' : 'FAILED',
+	       $connection["mailbox"],
+	       $connection["username"],
+        ];
+	}
+
+    protected function dumpToScreen(array $connections): void
+    {
+        $table = new Table($this->output);
+        $table->setHeaders(['Connection', 'Connect Result', 'Mailbox', 'Username']);
+
+        foreach($connections as $key => $connection)
+        {
+            $table->addRow($this->getRow($key, $connection));
+        }
+
+        $table->render();
+    }
+
+	protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+	    $this->input = $input;
+	    $this->output = $output;
+        $allowedConnections = $input->getArgument('connections');
+        $allAvailableConnections = $this->parameter->get('secit.imap.connections');
+        $connections = [];
+
+        # Filter to the allowed connections if set
+        if($allowedConnections)
+        {
+            foreach($allowedConnections as $key => $connection)
+            {
+                if(array_key_exists($connection, $allAvailableConnections))
+                {
+                    $connections[$connection] = $allAvailableConnections[$connection];
+                }
+                else
+                {
+                    $this->output->writeln('One or more Connections given are not available');
+                    return 1;
+                }
+            }
+        }
+        else
+        {
+            $connections = $allAvailableConnections;
+        }
+
+    	$this->dumpToScreen($connections);
+        $this->output->writeln('Total Connections: '.count($connections));
+
+        if($this->failed)
+        {
+         return 1;
+        }
+        else
+        {
+         return 0;
+         #return Command::SUCCESS; # Symfony > 5
+        }
+	}
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpPossiblePolymorphicInvocationInspection */
 
 namespace SecIT\ImapBundle\DependencyInjection;
 
@@ -18,13 +18,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('imap');
-
-        if (\method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('imap');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/DependencyInjection/ImapExtension.php
+++ b/DependencyInjection/ImapExtension.php
@@ -16,8 +16,9 @@ class ImapExtension extends Extension
 {
     /**
      * {@inheritdoc}
+     * @noinspection PhpUnhandledExceptionInspection
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/README.md
+++ b/README.md
@@ -25,27 +25,19 @@ If you're using Symfony Flex you're done and you can go to the configuration sec
 
 #### 2. Register bundle
 
-If you're not using Symfony Flex you must manually register this bundle in your AppKernel by adding the bundle declaration
+If you're not using Symfony Flex you must manually register this bundle in /config/bundles.php by adding the bundle declaration. 
 
 ```php
-class AppKernel extends Kernel
-{
-    public function registerBundles()
-    {
-        $bundles = [
-            ...
-            new SecIT\ImapBundle\ImapBundle(),
-        ];
-
-        ...
-    }
-}
+return [
+  ...
+  new SecIT\ImapBundle\ImapBundle(),
+];
 ```
 
 ## Configuration
 
-Setup your mailbox configuration. If your are using symfony 2.8 or 3.x without Symfony Flex add your configuration in `app/config/config.yml`.
-If you're using Symfony 4 or Symfony 3.x with Flex open the `config/packages/imap.yaml` and adjust its content.
+Setup your mailbox configuration.
+If you're using Symfony 4 with Flex open the `config/packages/imap.yaml` and adjust its content.
 
 Here is the example configuration:
 
@@ -74,7 +66,9 @@ imap:
             server_encoding: "UTF-8"
 ```
 
-If you're using Symfony to connect to a Microsoft 365 business environment, there's a good chance you'll want to connect to a shared mailbox. In that case you need to specify the parameters ```authuser``` and ```user```. Where *shared_account* is the username without domain, like:
+If you're using Symfony to connect to a Microsoft 365 business environment, there's a good chance you'll want to connect to a shared mailbox. 
+In that case you need to specify the parameters ```authuser``` and ```user```. 
+Where *shared_account* is the username without domain, like:
 
 ```yaml
 imap:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,3 +7,10 @@ services:
     SecIT\ImapBundle\Service\Imap:
         alias: secit.imap
         public: true
+
+    SecIT\ImapBundle\Command\ValidateConnectionsCommand:
+        public: false
+        tags: [console.command]
+        arguments: 
+            - '@SecIT\ImapBundle\Service\Imap'
+            - '@parameter_bag'

--- a/Service/Imap.php
+++ b/Service/Imap.php
@@ -17,7 +17,7 @@ class Imap
     /**
      * Imap constructor.
      *
-     * @param array $connections
+     * @param array<string, mixed> $connections
      */
     public function __construct(protected array $connections)
     {}

--- a/Service/Imap.php
+++ b/Service/Imap.php
@@ -11,37 +11,25 @@ use PhpImap\Mailbox;
  */
 class Imap
 {
-    /**
-     * @var array
-     */
-    protected $connections;
-
-    /**
-     * @var array|Mailbox[]
-     */
-    protected $instances = [];
+    /** @var Mailbox[] $instances */
+    protected array $instances = [];
 
     /**
      * Imap constructor.
      *
      * @param array $connections
      */
-    public function __construct(array $connections)
-    {
-        $this->connections = $connections;
-    }
+    public function __construct(protected array $connections)
+    {}
 
     /**
      * Get a connection to the specified mailbox.
      *
-     * @param string $name
-     * @param bool   $flush force to create a new Mailbox instance
-     *
-     * @return Mailbox
+     * @param bool $flush force to create a new Mailbox instance
      *
      * @throws \Exception
      */
-    public function get($name, $flush = false)
+    public function get(string $name, bool $flush = false): Mailbox
     {
         if ($flush || !isset($this->instances[$name])) {
             $this->instances[$name] = $this->getMailbox($name);
@@ -53,14 +41,11 @@ class Imap
     /**
      * Test mailbox connection.
      *
-     * @param string $name
-     * @param bool   $throwExceptions set to true if you'd like to get an exception on error instead of "return false"
-     *
-     * @return bool
+     * @param bool $throwExceptions set to true if you'd like to get an exception on error instead of "return false"
      *
      * @throws \Exception
      */
-    public function testConnection($name, $throwExceptions = false)
+    public function testConnection(string $name, bool $throwExceptions = false): bool
     {
         try {
             return $this->getMailbox($name)->getImapStream(true) !== null;
@@ -76,16 +61,12 @@ class Imap
     /**
      * Get new mailbox instance.
      *
-     * @param string $name
-     *
-     * @return Mailbox
-     *
      * @throws \Exception
      */
-    protected function getMailbox($name)
+    protected function getMailbox(string $name): Mailbox
     {
         if (!isset($this->connections[$name])) {
-            throw new \Exception(sprintf('Imap connection %s is not configured.', $name));
+            throw new \RuntimeException(sprintf('Imap connection %s is not configured.', $name));
         }
 
         $config = $this->connections[$name];
@@ -110,13 +91,11 @@ class Imap
     /**
      * Check attachments directory.
      *
-     * @param null|string $directoryPath
-     * @param bool        $createIfNotExists
-     * @param int         $directoryPermissions In decimal format! 775 instead of 0775
+     * @param int $directoryPermissions In decimal format! 775 instead of 0775
      *
      * @throws \Exception
      */
-    protected function checkAttachmentsDir($directoryPath, $createIfNotExists, $directoryPermissions)
+    protected function checkAttachmentsDir(?string $directoryPath, bool $createIfNotExists, int $directoryPermissions): void
     {
         if (!$directoryPath) {
             return;
@@ -124,11 +103,11 @@ class Imap
 
         if (file_exists($directoryPath)) {
             if (!is_dir($directoryPath)) {
-                throw new \Exception(sprintf('File "%s" exists but it is not a directory', $directoryPath));
+                throw new \RuntimeException(sprintf('File "%s" exists but it is not a directory', $directoryPath));
             }
 
             if (!is_readable($directoryPath) || !is_writable($directoryPath)) {
-                throw new \Exception(sprintf('Directory "%s" does not have enough access permissions', $directoryPath));
+                throw new \RuntimeException(sprintf('Directory "%s" does not have enough access permissions', $directoryPath));
             }
         } elseif ($createIfNotExists) {
             $umask = umask(0);
@@ -136,7 +115,7 @@ class Imap
             umask($umask);
 
             if (!$created) {
-                throw new \Exception(sprintf('Cannot create the attachments directory "%s"', $directoryPath));
+                throw new \RuntimeException(sprintf('Cannot create the attachments directory "%s"', $directoryPath));
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "symfony-bundle",
     "description": "PHP-IMAP Symfony integration.",
     "keywords": ["imap", "php-imap", "symfony", "bundle"],
-    "homepage": "http://secit.pl",
+    "homepage": "https://secit.pl",
     "license": "MIT",
     "authors": [
         {
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
-        "symfony/framework-bundle": "~4.0|~5.0|~6.0",
-        "symfony/dependency-injection": "~4.0|~5.0|~6.0",
-        "php-imap/php-imap": "~2.0|~3.0|~4.0|~5.0"
+        "php": ">=8.0",
+        "symfony/framework-bundle": "~4.4|~5.0|~6.0",
+        "symfony/dependency-injection": "~4.4|~5.0|~6.0",
+        "php-imap/php-imap": "~4.2|~5.0"
     },
     "autoload": {
         "psr-4": { "SecIT\\ImapBundle\\": "" }


### PR DESCRIPTION
#23

WIP: I need to test it first. Of course i would be glad if someone can help.

Symfony dependencies are at 4.4 as the latest supportet LTS from Symfony. < 4.4 are not maintained by symfony itself.

I guess this does not need to be nullable. Or is there a reason?
`protected function checkAttachmentsDir(?string $directoryPath`