### PR TITLE
Improve configuration definition

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,12 +27,12 @@ class Configuration implements ConfigurationInterface
         }
 
         $rootNode
-	        ->fixXmlConfig('connection')
+	    ->fixXmlConfig('connection')
             ->children()
                 ->arrayNode('connections')
                     ->isRequired()
                     ->requiresAtLeastOneElement()
-	                ->useAttributeAsKey('name')
+	            ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
                             ->scalarNode('mailbox')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,9 +27,12 @@ class Configuration implements ConfigurationInterface
         }
 
         $rootNode
+	        ->fixXmlConfig('connection')
             ->children()
                 ->arrayNode('connections')
                     ->isRequired()
+                    ->requiresAtLeastOneElement()
+	                ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
                             ->scalarNode('mailbox')


### PR DESCRIPTION
This allows you to use the new php based configuration without hassle:

```php
return static function(ImapConfig $imap): void
{
	$imap->connection('some_connection')
	     ->mailbox('a_mailbox');
	$imap->connection('second_connection')
	     ->mailbox('another_mailbox');
};
```