### PR TITLE
Use AsCommand in ValidateConnectionsCommand and ...

### DIFF
--- a/Command/ValidateConnectionsCommand.php
+++ b/Command/ValidateConnectionsCommand.php
@@ -20,13 +20,9 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * USE: php bin/console imap-bundle:validate-connections
  */
-# Symfony > 5.3
-##[AsCommand(name: 'imap-bundle:validate-connections', description: 'Validate if all Mailboxes can connect correct. If not, return 1.')]
+#[AsCommand(name: 'imap-bundle:validate-connections', description: 'Validate if all Mailboxes can connect correct. If not, return 1.')]
 class ValidateConnectionsCommand extends Command
 {
-    protected static $defaultName = 'imap-bundle:validate-connections';
-    protected static $defaultDescription = 'Validate if all Mailboxes can connect correct. If not, return 1.';
-
     protected ?InputInterface $input;
     protected ?OutputInterface $output;
     protected bool $failed = false;

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "secit-pl/imap-bundle",
+    "name": "ehymel/imap-bundle",
     "type": "symfony-bundle",
     "description": "PHP-IMAP Symfony integration.",
     "keywords": ["imap", "php-imap", "symfony", "bundle"],


### PR DESCRIPTION
Fix symfony6 deprecation... 
Use AsCommand in ValidateConnectionsCommand and remove changes to $defaultName and $defaultDescription