### PR TITLE
Fixing Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ imap:
             mailbox: ...
 ```
 
-You can get the connection inside a class by using service [autowiring](https://symfony.com/doc/current/service_container/autowiring.html) and using camelCased connection name + Connection as parameter name.  
+You can get the connection inside a class by using service [autowiring](https://symfony.com/doc/current/service_container/autowiring.html) and using camelCased connection name + `Connection` as parameter name.  
 
 ```php
 <?php
@@ -256,11 +256,11 @@ Be aware that this will disconnect your current connection and create a new one 
 
 ## Migration guide
 
-If you are upgrading from version prior to 3.0.0 to 3.x+ you may find that there are some BC breaks.
+Version 3.0.0 introduces some BC breaks.
 
 ### Connections getting
 
-Previously to get the connection you had to inject the `SecIT\ImapBundle\Service\Imap` service and from it get all connections.
+Previously to get the connection, you had to inject the `SecIT\ImapBundle\Service\Imap` service and get a connection from it.
 
 ```php
 public function index(Imap $imap)
@@ -273,7 +273,7 @@ After migration, you should use [autowiring](https://symfony.com/doc/current/ser
 
 ```php
 
-use SecIT\ImapBundle\ConnectionInterface;
+use SecIT\ImapBundle\Connection\ConnectionInterface;
 
 public function index(ConnectionInterface $exampleConnection)
 {


### PR DESCRIPTION
The important part is the wrong `use` line, the rest are minor rewordings.

Don't know why GitHub is showing line 299 ("The command changes its name from...") here in the diff - I didn't change anything there.

Some questions:
1. "and using camelCased connection name": Is camelCasing really required? For me, a snake_cased `foo_barConnection` worked as-is.
2. So what used to be:
    ```php
    $mailbox = $this->imap->get('foo');
    $mailbox->countMails();
    ```
    ... is now:
    ```php
    $this->fooConnection->getConnection()->countMails();
    ```
    Right? => The `->getConnection()` step is missing here in README.
3. The semantics are a bit irritating to me:  `->getConnection()` returns a `Mailbox`, whereas `->getMailbox()` returns a string?!