### PR TITLE
Fix deprecation

### DIFF
--- a/Command/ValidateConnectionsCommand.php
+++ b/Command/ValidateConnectionsCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -29,7 +29,7 @@ class ValidateConnectionsCommand extends Command
     private array $connections = [];
 
     public function __construct(
-        #[TaggedIterator('secit.imap.connection')]
+        #[AutowireIterator('secit.imap.connection')]
         iterable $connections
     ) {
         parent::__construct();


### PR DESCRIPTION
Since symfony/dependency-injection 7.1: The "Symfony\Component\DependencyInjection\Attribute\TaggedIterator" attribute is deprecated, use "Symfony\Component\DependencyInjection\Attribute\AutowireIterator" instead